### PR TITLE
Update minecraft_chorus.json

### DIFF
--- a/src/main/resources/assets/bonsaitrees/config/types.d/minecraft_chorus.json
+++ b/src/main/resources/assets/bonsaitrees/config/types.d/minecraft_chorus.json
@@ -2,18 +2,13 @@
   "name": "minecraft:chorus",
   "mod": "minecraft",
   "sapling": {
-    "name": "minecraft:chorus_fruit",
+    "name": "minecraft:chorus_flower",
     "data": 0
   },
   "growTimeMultiplier": 10.0,
   "drops": [
     {
       "name": "minecraft:chorus_fruit",
-      "data": 0,
-      "type": "WOOD"
-    },
-    {
-      "name": "minecraft:chorus_fruit_popped",
       "data": 0,
       "type": "FRUIT"
     },


### PR DESCRIPTION
Remove processed material (chorus_fruit_dropped, which requires a smelter to make) from drop list. Change sapling from chorus_fruit (which is a drop, not the sapling) to chorus_flower (the actual sapling).