### PR TITLE
[1.18.1] Fix server command /reload halting server logic

### DIFF
--- a/src/main/java/com/davenonymous/bonsaitrees3/registry/sapling/SaplingInfo.java
+++ b/src/main/java/com/davenonymous/bonsaitrees3/registry/sapling/SaplingInfo.java
@@ -88,4 +88,13 @@ public class SaplingInfo extends RecipeData {
 		return result;
 	}
 
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof SaplingInfo other && other.id.equals(this.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/com/davenonymous/bonsaitrees3/registry/soil/SoilInfo.java
+++ b/src/main/java/com/davenonymous/bonsaitrees3/registry/soil/SoilInfo.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class SoilInfo extends RecipeData {
@@ -64,5 +65,15 @@ public class SoilInfo extends RecipeData {
 
 	public float getTickModifier() {
 		return tickModifier;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof SoilInfo other && other.isFluid == this.isFluid && other.id.equals(this.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, isFluid);
 	}
 }


### PR DESCRIPTION
The /reload command repopulates the soilCompatiblity HashMap in SoilCompatibility.
the cantreeGrowOnSoil method contains a check to see if a sapling or soil is present in this HashMap.
Because both SaplingInfo and SoilInfo are void of an equals and a hash method, these checks will never pass after the map is repopulated, because it will compare on object instance instead.

Solution :
Add equals and hashcode to SaplingInfo.
Add equals and hashcode to SoilInfo.

Fixes : /reload command halting server side logic and trees stop growing

*Sponsored by the [Modding Inquisition](https://github.com/TheModdingInquisition)*