### PR TITLE
Fix race condition with lighting updates

### DIFF
--- a/src/main/java/com/davenonymous/bonsaitrees/blocks/BonsaiPotBlock.java
+++ b/src/main/java/com/davenonymous/bonsaitrees/blocks/BonsaiPotBlock.java
@@ -130,12 +130,7 @@ public class BonsaiPotBlock extends Block implements EntityBlock, Equipable, Sim
 	@Override
 	public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
 		if(level.getBlockEntity(pos) instanceof BonsaiPotBlockEntity bonsaiPot) {
-			if(bonsaiPot.production.getBonsaiInfo().isPresent()) {
-				BonsaiInfo info = bonsaiPot.production.getBonsaiInfo().get();
-				if(info.lightEmission().isPresent()) {
-					return info.lightEmission().get();
-				}
-			}
+			return bonsaiPot.production.getBonsaiInfo().flatMap(BonsaiInfo::lightEmission).orElse(0);
 		}
 		return 0;
 	}


### PR DESCRIPTION
Surface level fix that prevents the following crash: [crash-2025-11-10_18.11.45-client.txt](https://github.com/user-attachments/files/23459290/crash-2025-11-10_18.11.45-client.txt)
