### PR TITLE
Fixes pale oak having no loot

### DIFF
--- a/src/main/resources/datapacks/vanillabackport/data/bonsaitrees4/data_maps/item/bonsai.json
+++ b/src/main/resources/datapacks/vanillabackport/data/bonsaitrees4/data_maps/item/bonsai.json
@@ -6,7 +6,7 @@
     }
   ],
   "values": {
-    "vanillabackport:pale_oak_sapling": {
+    "minecraft:pale_oak_sapling": {
       "model": "vanillabackport:pale_oak_bonemeal"
     }
   }

--- a/src/main/resources/datapacks/vanillabackport/data/bonsaitrees4/loot_table/bonsai/vanillabackport/pale_oak_bonemeal.json
+++ b/src/main/resources/datapacks/vanillabackport/data/bonsaitrees4/loot_table/bonsai/vanillabackport/pale_oak_bonemeal.json
@@ -17,7 +17,7 @@
          "entries" : [
             {
                "type" : "minecraft:loot_table",
-               "value" : "vanillabackport:blocks/pale_oak_log"
+               "value" : "minecraft:blocks/pale_oak_log"
             }
          ],
          "name" : "log",
@@ -34,7 +34,7 @@
          "entries" : [
             {
                "type" : "minecraft:loot_table",
-               "value" : "vanillabackport:blocks/pale_oak_leaves"
+               "value" : "minecraft:blocks/pale_oak_leaves"
             }
          ],
          "name" : "leaves",


### PR DESCRIPTION
Vanilla backport uses the Minecraft namespace for their mod as of version 1.1.5 released November 16, 2025. This pull request fixes the datapack so it works again.